### PR TITLE
Filter empty state styling {Do Not Merge}

### DIFF
--- a/app/components/api-tree.js
+++ b/app/components/api-tree.js
@@ -30,7 +30,6 @@ export default Ember.Component.extend({
 
         let definedTags = this.get('apiService').get('api').tags;
         let actualTags = Object.keys(this.get('apiService').get('methodsByTag'));
-
         let tags = [];
 
         for(let x= 0; x< definedTags.length; x++){
@@ -42,4 +41,8 @@ export default Ember.Component.extend({
 
         return tags;
     }),
+    hasMethods: computed('filter', function() {
+        return !this.get('apiService').areAllMethodsFilteredOut(this.get("filter"));
+
+    })
 });

--- a/app/components/tag-apis.js
+++ b/app/components/tag-apis.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
     description: null,
     filter: null,
     documentation: null,
-    
+
     groupMethods(tagName, filteredMethods){
         var groupMethods = {
             methods: [],
@@ -57,18 +57,20 @@ export default Ember.Component.extend({
         return groupMethods;
     },
     methods: computed('filter', function() {
-         let tagName = this.get('name');
+        let tagName = this.get('name');
         let apis = this.get('apiService').filteredMethodsByTag(tagName, this.get("filter"));
+
         apis = this.groupMethods(tagName, apis);
         return apis;
     }),
 
     hasMethods: computed('filter', function() {
-         let tagName = this.get('name');
+        let tagName = this.get('name');
         let apis = this.get('apiService').filteredMethodsByTag(tagName, this.get("filter"));
-        return apis.length >0;
-    }),
+        let hasMethods =  apis.length >0;
 
+        return hasMethods;
+    }),
     didReceiveAttrs() {
       this._super(...arguments);
 
@@ -76,7 +78,6 @@ export default Ember.Component.extend({
       let apis = this.get('apiService').filteredMethodsByTag(tagName, this.get("filter"));
 
       this.set('hasMethods', apis.length > 0);
-    // this.set('methods', apis);
       this.get("name");
 
   }

--- a/app/services/api-service.js
+++ b/app/services/api-service.js
@@ -26,6 +26,29 @@ export default Ember.Service.extend({
 
         return filteredMethods;
     },
+
+    areAllMethodsFilteredOut(filter){
+        let methodsMap = this.get("methodsByTag");
+
+        for(let key in methodsMap){
+            let methods = methodsMap[key];
+
+            if(filter == null || filter === ""){
+                return false;
+            }
+            filter = filter.toLowerCase();
+
+            for(let x=0; x<methods.length; x++){
+                let method = methods[x];
+                if(method.summary.toLowerCase().indexOf(filter) > -1){
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    },
+
     processSchema(schema, self){
 
 

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -124,10 +124,17 @@ body, html {
     flex-flow: column;
     height: 100%;
     margin-top: 40px;
+    margin-left: 0;
     position: fixed;
     left: @sidebar-width;
     width: calc(100% ~"-" @sidebar-width);
     justify-content: center;
+
+    &.empty-state-sidebar {
+        left: 0;
+        margin-top: 0;
+        width: @sidebar-width;
+    }
 
     > *  {
         margin: 0 auto;

--- a/app/templates/components/api-tree.hbs
+++ b/app/templates/components/api-tree.hbs
@@ -3,19 +3,23 @@
       <div class="form-group">
         {{input value=filter id='api-search' class="form-control"  placeholder="Filter"}}
       </div>
+
     </form>
     <div>
+        {{#if (eq hasMethods true)}}
+        <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" >
+            {{#each tags as |tag|}}
+                {{tag-apis name=tag.name description=tag.description filter=filter documentation=tag.externalDocs.url}}
+            {{/each}}
+        </div>
+        {{else}}
         <div class="no-results">
           <div class='empty-state empty-state-sidebar'>
               <i class="pc-moon pc-search" aria-hidden="true"></i>
               <label>No filter results</label>
           </div>
         </div>
-        <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" >
-            {{#each tags as |tag|}}
-                {{tag-apis name=tag.name description=tag.description filter=filter documentation=tag.externalDocs.url}}
-            {{/each}}
-        </div>
+        {{/if}}
     </div>
 </div>
 {{#api-info}}{{/api-info}}

--- a/app/templates/components/api-tree.hbs
+++ b/app/templates/components/api-tree.hbs
@@ -5,10 +5,11 @@
       </div>
     </form>
     <div>
-        <div class='no-results'>
-            <label>
-                No results for defined filter
-            </label>
+        <div class="no-results">
+          <div class='empty-state empty-state-sidebar'>
+              <i class="pc-moon pc-search" aria-hidden="true"></i>
+              <label>No filter results</label>
+          </div>
         </div>
         <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" >
             {{#each tags as |tag|}}


### PR DESCRIPTION
@KevinGlinski Since I want to vertically center the no-results message, the no-results message is now displaying after an applied valid filter.

Right now, `.no-results` is always visible. If we can add `.hide` to `.no-results` on valid filters, then I think my issue will be resolved.

<img width="300" alt="screen shot 2016-08-23 at 1 39 48 pm" src="https://cloud.githubusercontent.com/assets/485903/17902874/1ba32354-6937-11e6-9ca1-6191312d549d.png">