### PR TITLE
Debounce the api filter to allow for smoother typing

### DIFF
--- a/app/components/api-tree.js
+++ b/app/components/api-tree.js
@@ -4,20 +4,32 @@ var  computed = Ember.computed;
 
 export default Ember.Component.extend({
     apiService: Ember.inject.service('apiService'),
+
     filter:null,
+
+    _filter:null, // bound to text input
+    // debounce setting the filter binding to allow for smooth typing
+    debounceFilter: Ember.observer('_filter', function () {
+        Ember.run.debounce(this, this.setFilter, 150);
+    }),
+
+    setFilter() {
+        this.set('filter', this.get('_filter'));
+    },
+
     querystringService: Ember.inject.service(),
     init(){
         this._super(...arguments);
 
         let filter = this.get("querystringService").getParameter(window.location.search, "filter");
         if(filter){
-            this.set("filter", filter);
+            this.set("_filter", filter);
         }
 
     },
     didInsertElement(){
         this._super(...arguments);
-        if(this.get('filter')){
+        if(this.get('_filter')){
             $('.panel-title a').removeClass("collapsed");
             $(".panel-collapse").addClass("in");
         }

--- a/app/templates/components/api-tree.hbs
+++ b/app/templates/components/api-tree.hbs
@@ -1,7 +1,7 @@
 <div id="api-tree">
     <form onkeypress="return event.keyCode != 13;">
       <div class="form-group">
-        {{input value=filter id="api-search" class="form-control"  placeholder="Filter"}}
+        {{input value=_filter id="api-search" class="form-control"  placeholder="Filter"}}
       </div>
 
     </form>


### PR DESCRIPTION
Before (when it seems frozen, I'm actually typing):
![filter-before](https://user-images.githubusercontent.com/833911/56752748-037f4980-6757-11e9-87ca-d48753051042.gif)

After:
![filter-after](https://user-images.githubusercontent.com/833911/56752761-09752a80-6757-11e9-91d6-93b302e9014d.gif)
