### PR TITLE
DEVCTR-19: API Explorer boolean query parameter needs three states

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ The Open API explorer accepts a couple URL parameters for configuration
 
 token_type and access_token are in the url hash to support oauth redirects.
 
-Assuming that the OpenAPI explorer is hosted at https://developer.mypurecloud.com/openapi-explorer/, an example would be:
+Assuming that the OpenAPI explorer is hosted at https://developer.mypurecloud.com/developer-tools/#/api-explorer, an example would be:
 
-https://developer.mypurecloud.com/openapi-explorer/?openApiUrl=https://api.mypurecloud.com/api/v2/docs/swagger#token_type=bearer&access_token=Uf7UTEjT9SknXhdUz
+https://developer.mypurecloud.com/developer-tools/#/api-explorer/?openApiUrl=https://api.mypurecloud.com/api/v2/docs/swagger#token_type=bearer&access_token=Uf7UTEjT9SknXhdUz
 
 ## Restrictions
 

--- a/app/components/parameter-input.js
+++ b/app/components/parameter-input.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
         if(["int32","int64","float","double"].indexOf(parameter.format) > -1 ){
             return "number";
         }else if (parameter.type === "boolean"){
-            return "checkbox";
+            return "select";
         }else if (parameter.type === "date"){
             return "date";
         }else if (parameter.type === "date-time"){
@@ -34,5 +34,11 @@ export default Ember.Component.extend({
             return "";
         }
 
-    })
+    }),
+
+    actions: {
+        selectBooleanParameter(value) {
+            this.set("parameter.value", value);
+        }
+    },
 });

--- a/app/templates/components/parameter-input.hbs
+++ b/app/templates/components/parameter-input.hbs
@@ -3,8 +3,12 @@
         <div class="form-group">
             <label class="control-label col-sm-2">{{parameter.name}}</label>
             <div class="col-sm-2">
-                {{#if (eq inputType "checkbox")}}
-                {{input class="form-control" checked=parameter.value  required=parameter.required type=inputType }}
+                {{#if (eq inputType "select")}}
+                <select class="form-control" required={{parameter.required}} onchange={{action "selectBooleanParameter" value="target.value"}}>
+                    <option value="">Not specified</option>
+                    <option value="true">True</option>
+                    <option value="false">False</option>
+                </select>
                 {{else}}
                 {{input class="form-control" value=parameter.value  required=parameter.required type=inputType }}
                 {{/if}}
@@ -18,10 +22,10 @@
             <div class="col-sm-5">
                 {{parameter.description}}
                 {{#if parameter.items.enum}}
-                <b>Valid values: </b> {{join ', ' parameter.items.enum }}
+                <b>Valid values: </b> {{join ", " parameter.items.enum }}
                 {{/if}}
                 {{#if parameter.enum}}
-                <b>Valid values: </b> {{join ', ' parameter.enum }} 
+                <b>Valid values: </b> {{join ", " parameter.enum }} 
                 {{/if}}
             </div>
         </div>


### PR DESCRIPTION
Replacing checkbox with dropdown-list to allow users to specify 3 different states for booleans; Not specified, True and False. 

For instance:
/api/v2/users/{userId}/queues
/api/v2/users/{userId}/queues?joined=true
/api/v2/users/{userId}/queues?joined=false
