### PR TITLE
Fix formatting of application/scim+json responses

### DIFF
--- a/app/components/api-request.js
+++ b/app/components/api-request.js
@@ -250,9 +250,10 @@ export default Ember.Component.extend({
             function handleResponse(xhResponse){
 
                 let responseData = xhResponse.responseText;
+                const jsonContentTypes = ["application/json", "application/scim+json"];
 
                 try{
-                    if(xhResponse.getResponseHeader("Content-Type") === "application/json"){
+                    if(jsonContentTypes.includes(xhResponse.getResponseHeader("Content-Type"))){
                         responseData = JSON.stringify(JSON.parse(xhResponse.responseText), null, "  ");
                     }
                 }catch(err){}


### PR DESCRIPTION
Responses returned by the PureCloud SCIM API aren't formatted in the response body editor field unlike the other endpoints.
This is because JSON responses are formatted only when the Content-type is `application/json` but the SCIM API responses have a `application/scim+json` type (https://www.iana.org/assignments/media-types/application/scim+json).

This is a minor fix to address this.